### PR TITLE
Kerbal Status Effects integration

### DIFF
--- a/DutyRoster/DutyRoster.cfg
+++ b/DutyRoster/DutyRoster.cfg
@@ -1,0 +1,8 @@
+KERBAL_STATUS_EFFECT {
+    name = dutyroster_offduty
+    title = off duty
+    description = This kerbal is enjoying their scheduled time off from work.
+    impact = INCAPACITATED
+    mod = Duty Roster
+    SKILL_REMOVE_ALL_EXCEPT{}
+}


### PR DESCRIPTION
Just shipped Kerbal Status Effects 0.1.0 dev build [here](https://github.com/cake-pie/KerbalStatusEffects/releases/tag/v0.1.0) with the barebones functionality needed for Duty Roster. You'll have to do a hard dependency for now but at least you won't be blocked while I work on fleshing things out further.

This PR adds the config you'll need.  
If you want to set Tourists to be ineligible to be affected (as a safety measure), add
`ineligible_trait = Tourist`

You'll probably want to declare a const in your code somewhere
`private const string StatusEffect = "dutyroster_offduty";`
and then it's pretty much just
`pcm.ApplyStatusEffect(StatusEffect);`
`pcm.RemoveStatusEffect(StatusEffect);`

You may find the `/kse` command in the Ctrl-Alt-F12 console helpful for inspection and debugging.

Feel free to holler if anything comes up.